### PR TITLE
Use cached dependencies during build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM golang:1.17.7-bullseye as builder
 RUN mkdir /build 
-ADD . /build/
 WORKDIR /build 
+COPY go.* ./
+RUN go mod download
+COPY . .
 RUN make build-prod
 RUN ls config/
 


### PR DESCRIPTION
This way docker will reuse cached dependencies and won't have to download them again if there is no change in go.mod or go.sum files